### PR TITLE
Mouse delta

### DIFF
--- a/bootstrap/Input.cpp
+++ b/bootstrap/Input.cpp
@@ -58,11 +58,16 @@ Input::Input() {
 			f(window, xoffset, yoffset);
 	};
 
+	auto MouseEnterCallback = [](GLFWwindow* window, int entered) {
+		Input::getInstance()->m_firstMouseMove = true;
+	};
+
 	glfwSetKeyCallback(window, KeyPressCallback);
 	glfwSetCharCallback(window, CharacterInputCallback);
 	glfwSetMouseButtonCallback(window, MouseInputCallback);
 	glfwSetCursorPosCallback(window, MouseMoveCallback);
 	glfwSetScrollCallback(window, MouseScrollCallback);
+	glfwSetCursorEnterCallback(window, MouseEnterCallback);
 	
 	m_mouseX = 0;
 	m_mouseY = 0;
@@ -77,6 +82,12 @@ Input::~Input() {
 void Input::onMouseMove(int newXPos, int newYPos) {
 	m_mouseX = newXPos;
 	m_mouseY = newYPos;
+	if (m_firstMouseMove) {
+		// On first move after startup/entering window reset old mouse position
+		m_oldMouseX = newXPos;
+		m_oldMouseY = newYPos;
+		m_firstMouseMove = false;
+	}
 }
 
 void Input::clearStatus() {
@@ -101,6 +112,10 @@ void Input::clearStatus() {
 		m_lastButtons[i] = m_currentButtons[i];
 		m_currentButtons[i] = glfwGetMouseButton(window, i);
 	}
+
+	// update old mouse position
+	m_oldMouseX = m_mouseX;
+	m_oldMouseY = m_mouseY;
 }
 
 bool Input::isKeyDown(int inputKeyID) {
@@ -162,6 +177,22 @@ double Input::getMouseScroll() {
 void Input::getMouseXY(int* x, int* y) {
 	if ( x != nullptr ) *x = m_mouseX;
 	if ( y != nullptr) *y = m_mouseY;
+}
+
+int Input::getMouseDeltaX()
+{
+	return m_mouseX - m_oldMouseX;
+}
+
+int Input::getMouseDeltaY()
+{
+	return m_mouseY - m_oldMouseY;
+}
+
+void Input::getMouseDelta(int * x, int * y)
+{
+	if (x != nullptr ) *x = m_mouseX - m_oldMouseX;
+	if (y != nullptr) *y = m_mouseY - m_oldMouseY;
 }
 
 } // namespace aie

--- a/bootstrap/Input.cpp
+++ b/bootstrap/Input.cpp
@@ -59,6 +59,7 @@ Input::Input() {
 	};
 
 	auto MouseEnterCallback = [](GLFWwindow* window, int entered) {
+		// Set flag to prevent large mouse delta on entering screen
 		Input::getInstance()->m_firstMouseMove = true;
 	};
 

--- a/bootstrap/Input.h
+++ b/bootstrap/Input.h
@@ -168,6 +168,11 @@ public:
 	int getMouseY();
 	void getMouseXY(int* x, int* y);
 
+	// query mouse movement
+	int getMouseDeltaX();
+	int getMouseDeltaY();
+	void getMouseDelta(int* x, int* y);
+
 	// query how far the mouse wheel has been moved 
 	double getMouseScroll();
 
@@ -212,7 +217,11 @@ private:
 		
 	int		m_mouseX;
 	int		m_mouseY;
+	int		m_oldMouseX;
+	int		m_oldMouseY;
 	double	m_mouseScroll;
+
+	bool	m_firstMouseMove;	// flag for first mouse input after start or mouse entering window
 
 	void onMouseMove(int newXPos, int newYPos);
 	


### PR DESCRIPTION
This pull request adds functions for getting mouse movement to the Input class. The purpose of including this functionality in Bootstrap is correctly dealing with the mouse cursor entering and leaving the window.

When clearStatus is called, the previous mouse position is stored. The getMouseDelta functions return the difference between these and the mouse position as set in onMouseMove. 

When the mouse leaves the window (and on the first update), m_firstMouseMove is set to true. This means that the next time onMouseMove is called, the previous mouse position will also be updated, giving a mouse delta of 0. This prevents very large mouse deltas from being reported on the first update (comparing {0,0} to the mouse's position) and when entering the window (comparing the exit position to the entry position). 