### PR TITLE
Added camera scale to 2D renderer for zooming

### DIFF
--- a/bootstrap/Renderer2D.cpp
+++ b/bootstrap/Renderer2D.cpp
@@ -15,6 +15,7 @@ Renderer2D::Renderer2D() {
 
 	m_cameraX = 0;
 	m_cameraY = 0;
+	m_cameraScale = 1.0f;
 
 	unsigned int pixels[1] = {0xFFFFFFFF};
 	m_nullTexture = new Texture(1, 1, Texture::RGBA, (unsigned char*)pixels);
@@ -157,7 +158,21 @@ void Renderer2D::begin() {
 	
 	glUseProgram(m_shader);
 
-	auto projection = glm::ortho(m_cameraX, m_cameraX + (float)width, m_cameraY, m_cameraY + (float)height, 1.0f, -101.0f);
+	// scale the width/height based on cameraScale
+	float scaledWidth  = (float)width * m_cameraScale;
+	float scaledHeight = (float)height * m_cameraScale;
+
+	// get the middle of the window in order to get the scaled bounds
+	float midX = m_cameraX + (width  / 2.0f);
+	float midY = m_cameraY + (height / 2.0f);
+
+	// get the bounds to use in the projection matrix
+	float top    = midY + (scaledHeight / 2.0f);
+	float left   = midX - (scaledWidth / 2.0f);
+	float right  = midX + (scaledWidth / 2.0f);
+	float bottom = midY - (scaledHeight / 2.0f);
+
+	auto projection = glm::ortho(left, right, bottom, top, 1.0f, -101.0f);
 	glUniformMatrix4fv(glGetUniformLocation(m_shader, "projectionMatrix"), 1, false, &projection[0][0]);
 
 	glEnable(GL_BLEND);

--- a/bootstrap/Renderer2D.h
+++ b/bootstrap/Renderer2D.h
@@ -46,6 +46,10 @@ public:
 	void setCameraPos(float x, float y) { m_cameraX = x; m_cameraY = y; }
 	void getCameraPos(float& x, float& y) const { x = m_cameraX; y = m_cameraY; }
 
+	// specify the camera scale/zoom
+	void  setCameraScale(float scale) { m_cameraScale = scale; }
+	float getCameraScale() { return m_cameraScale; }
+
 protected:
 
 	// helper methods used during drawing
@@ -58,6 +62,8 @@ protected:
 
 	// the camera position
 	float				m_cameraX, m_cameraY;
+	// the camera scale (zoom) - lower = zoomed in, higher = zoomed out
+	float				m_cameraScale;
 
 	// texture handling
 	enum { TEXTURE_STACK_SIZE = 16 };


### PR DESCRIPTION
A little scale parameter to "zoom" the camera in/out which I've been using in my projects

This is identical to pull request #10 which I closed to make some changes to my fork before realising I could duplicate the repo and keep the pull request active.