### PR TITLE
Add CMake support to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ x86/
 bld/
 [Oo]bj/
 
+#Cmake ignore 
+build/
+*/build/ #Make more restricted if a /build/ folder needs to be included
+
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dependencies/glfw-source"]
+	path = dependencies/glfw-source
+	url = https://github.com/glfw/glfw.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+project(aieBootstrapProject)
+
+#TODO: Update to use the target_complile_requires
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(OpenGL REQUIRED)
+
+
+#add build glfw
+option(GLFW_BUILD_EXAMPLES NO)
+option(GLFW_BUILD_TESTS NO)
+add_subdirectory(${PROJECT_SOURCE_DIR}/dependencies/glfw-source)
+
+add_subdirectory(bootstrap)
+
+
+#PROJECT TO BUILD
+add_subdirectory(project3D)

--- a/bootstrap/Application.cpp
+++ b/bootstrap/Application.cpp
@@ -144,7 +144,7 @@ void Application::setVSync(bool enable) {
 }
 
 void Application::setShowCursor(bool visible) {
-	ShowCursor(visible);
+    glfwSetInputMode(m_window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 }
 
 unsigned int Application::getWindowWidth() const {

--- a/bootstrap/Application.cpp
+++ b/bootstrap/Application.cpp
@@ -144,7 +144,11 @@ void Application::setVSync(bool enable) {
 }
 
 void Application::setShowCursor(bool visible) {
-    glfwSetInputMode(m_window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+#ifdef _MSC_VER
+    ShowCursor(visible);
+#else
+    glfwSetInputMode(m_window, GLFW_CURSOR, visible ? GLFW_CURSOR_HIDDEN : GLFW_CURSOR_HIDDEN);
+#endif
 }
 
 unsigned int Application::getWindowWidth() const {

--- a/bootstrap/CMakeLists.txt
+++ b/bootstrap/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+project(aieBootstrap)
+
+add_library(${PROJECT_NAME}
+    Application.cpp
+    Font.cpp
+    Gizmos.cpp
+    Input.cpp
+    Renderer2D.cpp
+    Texture.cpp
+    gl_core_4_4.c
+    imgui_glfw3.cpp
+    ${CMAKE_SOURCE_DIR}/dependencies/imgui/imgui_draw.cpp 
+    ${CMAKE_SOURCE_DIR}/dependencies/imgui/imgui.cpp 
+ )
+
+target_link_libraries(${PROJECT_NAME}
+    glfw
+    ${OPENGL_gl_LIBRARY}
+    )
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    ${PROJECT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/dependencies/glm
+    ${CMAKE_SOURCE_DIR}/dependencies/imgui
+    ${CMAKE_SOURCE_DIR}/dependencies/stb
+    ${CMAKE_SOURCE_DIR}/dependencies/glfw/include
+    ${CMAKE_SOURCE_DIR}/dependencies/openal/include
+    )

--- a/bootstrap/Font.cpp
+++ b/bootstrap/Font.cpp
@@ -15,15 +15,19 @@ Font::Font(const char* trueTypeFontFile, unsigned short fontHeight)
 	m_textureHeight(0) {
 	
 	FILE* file = nullptr;
+#ifdef _MSC_VER
 	fopen_s(&file, trueTypeFontFile, "rb");
-	if (file != nullptr) {
+#else
+	file = fopen(trueTypeFontFile, "rb");
+#endif
+    if (file != nullptr) {
 		
 		unsigned char* ttf_buffer = new unsigned char[4096 * 1024];
 
 		fread(ttf_buffer, 1, 4096 * 1024, file);
 		fclose(file);
 
-		// determine size of texture image
+		// determie size of texture image
 		m_textureWidth = fontHeight / 16 * 256;
 		m_textureHeight = fontHeight / 16 * 256;
 

--- a/bootstrap/Font.cpp
+++ b/bootstrap/Font.cpp
@@ -27,7 +27,7 @@ Font::Font(const char* trueTypeFontFile, unsigned short fontHeight)
 		fread(ttf_buffer, 1, 4096 * 1024, file);
 		fclose(file);
 
-		// determie size of texture image
+		// determine size of texture image
 		m_textureWidth = fontHeight / 16 * 256;
 		m_textureHeight = fontHeight / 16 * 256;
 

--- a/bootstrap/Font.cpp
+++ b/bootstrap/Font.cpp
@@ -15,8 +15,12 @@ Font::Font(const char* trueTypeFontFile, unsigned short fontHeight)
 	m_textureHeight(0) {
 	
 	FILE* file = nullptr;
+#ifdef _MSC_VER
 	fopen_s(&file, trueTypeFontFile, "rb");
-	if (file != nullptr) {
+#else
+	file = fopen(trueTypeFontFile, "rb");
+#endif
+    if (file != nullptr) {
 		
 		unsigned char* ttf_buffer = new unsigned char[4096 * 1024];
 

--- a/bootstrap/Renderer2D.cpp
+++ b/bootstrap/Renderer2D.cpp
@@ -34,7 +34,7 @@ Renderer2D::Renderer2D() {
 		m_fontTexture[i] = 0;
 	}
 
-	char* vertexShader = "#version 150\n \
+	const char* vertexShader = "#version 150\n \
 						in vec4 position; \
 						in vec4 colour; \
 						in vec2 texcoord; \
@@ -45,7 +45,7 @@ Renderer2D::Renderer2D() {
 						void main() { vColour = colour; vTexCoord = texcoord; vTextureID = position.w; \
 						gl_Position = projectionMatrix * vec4(position.x, position.y, position.z, 1.0f); }";
 
-	char* fragmentShader = "#version 150\n \
+	const char* fragmentShader = "#version 150\n \
 						in vec4 vColour; \
 						in vec2 vTexCoord; \
 						in float vTextureID; \
@@ -97,7 +97,11 @@ Renderer2D::Renderer2D() {
 	// set texture locations
 	char buf[32];
 	for (int i = 0; i < TEXTURE_STACK_SIZE; ++i) {
+#ifdef _MSC_VER
 		sprintf_s(buf, "textureStack[%i]", i);
+#else
+		sprintf(buf, "textureStack[%i]", i);
+#endif
 		glUniform1i(glGetUniformLocation(m_shader, buf), i);
 	}
 
@@ -649,7 +653,11 @@ void Renderer2D::flushBatch() {
 		return; char buf[32];
 
 	for (int i = 0; i < TEXTURE_STACK_SIZE; ++i) {
+#ifdef _MSC_VER
 		sprintf_s(buf, "isFontTexture[%i]", i);
+#else
+		sprintf(buf, "isFontTexture[%i]", i);
+#endif
 		glUniform1i(glGetUniformLocation(m_shader, buf), m_fontTexture[i]);
 	}
 

--- a/project2D/Application2D.cpp
+++ b/project2D/Application2D.cpp
@@ -2,6 +2,7 @@
 #include "Texture.h"
 #include "Font.h"
 #include "Input.h"
+#include <cmath>
 
 Application2D::Application2D() {
 
@@ -96,7 +97,11 @@ void Application2D::draw() {
 	
 	// output some text, uses the last used colour
 	char fps[32];
+#ifdef _MSC_VER
 	sprintf_s(fps, 32, "FPS: %i", getFPS());
+#else
+    sprintf(fps, "FPS: %i", getFPS());
+#endif
 	m_2dRenderer->drawText(m_font, fps, 0, 720 - 32);
 	m_2dRenderer->drawText(m_font, "Press ESC to quit!", 0, 720 - 64);
 

--- a/project2D/CMakeLists.txt
+++ b/project2D/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+project(project2D)
+
+add_executable(${PROJECT_NAME}
+    main.cpp
+    Application2D.cpp
+    )
+target_link_libraries(${PROJECT_NAME} aieBootstrap)

--- a/project3D/CMakeLists.txt
+++ b/project3D/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+project(project3D)
+
+add_executable(${PROJECT_NAME}
+    main.cpp
+    Application3D.cpp
+    )
+target_link_libraries(${PROJECT_NAME} aieBootstrap)


### PR DESCRIPTION
Adds CMake support to the project along with a few small changes to the code base to allow for cross-platform builds.

In order for this to work correctly, I have added glfw's git repository as a submodule so that it can be pulled down by those who want access to it, but without it needing to take up space in the actual AIE bootstrap repository.

The top-level CMakeLists.txt file will build the bootstrap and any given projects. See the project2D and project3D project for examples of CMakeLists.txt files.

I have not included any tools or helper functionality yet for quickly making new projects, but this will give anyone who needs a cross-platform version of the bootstrap a place to start.
